### PR TITLE
Set codex-review as default review method

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -5,6 +5,7 @@
 - **auto-git-workflow**: Always use the `/git-workflow` skill (not manual git commands) for feature branch work. Follow the skill step-by-step—every phase is mandatory. Complete phases without pausing for explicit user prompts.
 - **auto-cleanup-after-merge**: After merging a PR (whether user merges or Claude merges), automatically clean up local git: checkout main, pull, delete merged feature branches.
 - **practice-review-prompts**: At the end of substantive sessions (meaningful work, not quick questions), offer to run `/practice-review` if the session touched areas covered by `~/.claude/practices.md`. Phrase as: "This session touched [area]. Want to run `/practice-review` to reflect on how it went?"
+- **review-method: codex-review** — Use OpenAI Codex (via `/codex-review`) for self-review in git-workflow Phase 3. Faster than review-debate, external perspective from different model family.
 
 ## Subagent Context Management
 


### PR DESCRIPTION
## Summary
- Use OpenAI Codex (`/codex-review`) for self-review in git-workflow Phase 3 instead of `review-debate`
- Faster for medium-sized changes (single model call vs 3 parallel subagents)
- External perspective from different model family

## Changes
- Added `review-method: codex-review` to global CLAUDE.md workflow preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)